### PR TITLE
Fix early sends with absolute time pushes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "winston": "^2.3.1"
   },
   "devDependencies": {
-    "eslint": "^4.5.0",
+    "eslint": "^5.2.0",
     "eslint-config-google": "^0.9.1",
     "jasmine": "^2.6.0",
     "nyc": "^11.9.0",

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -77,16 +77,17 @@ function createPushWorkItems(pushStatus, applicationId, now) {
 
   let pushTime = pushStatus.get('pushTime');
   if (pushTimeHasTimezoneComponent(pushTime)) {
-    const ttl = Date.parse(pushTime) + (SEND_TIME_VARIANCE * 1000);
-    if (+now > +ttl) {
-      return [];
+    const latestSendTime = Date.parse(pushTime) + (SEND_TIME_VARIANCE * 1000);
+
+    if (
+      pushStatus.get('status') === 'scheduled' &&
+      now.valueOf() >= Date.parse(pushTime) && // earliest send time
+      now.valueOf() <= latestSendTime
+    ) {
+      return [ offsetToPwi(undefined) ];
     }
 
-    if (pushStatus.get('status') !== 'scheduled') {
-      return [];
-    }
-
-    return [ offsetToPwi(undefined) ];
+    return [];
   }
 
   pushTime = new Date(pushTime);


### PR DESCRIPTION
## Changes
`createPushWorkItems` only checked if the push time exceeded the grace window for absolute time pushes. These changes check within the `SEND_TIME_VARIANCE` interval where the earliest push time is `pushTime` and the latest push time is `pushTime + 5mins`